### PR TITLE
Disable automerge for dependency reconfix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+	"extends": ["github>balena-io/renovate-config"],
+	"packageRules": [
+		{
+			"matchDatasources": ["npm"],
+			"matchPackageNames": ["reconfix"],
+			"automerge": false
+		}
+	]
+}


### PR DESCRIPTION
This is one of the messy modules that we are using a random branch from a random pr from years and years ago and we should not automerge any changes without inspection.

Change-type: patch

See: https://github.com/balena-io-modules/balena-device-init/pull/62

See: [#balena-io > balena CLI building with PKG @ 💬](https://balena.zulipchat.com/#narrow/channel/345890-balena-io/topic/balena.20CLI.20building.20with.20PKG/near/522829433)